### PR TITLE
Created set_parameters function in ps3eyedriver to expose set_<parm>

### DIFF
--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -124,6 +124,8 @@ public:
 		blueblc = val;
 		sccb_reg_write(0x42, val);
 	}
+    bool getFlipH() const { return flip_h; }
+    bool getFlipV() const { return flip_v; }
 	void setFlip(bool horizontal = false, bool vertical = false) {
         flip_h = horizontal;
         flip_v = vertical;

--- a/src/ps3eyedriver.cpp
+++ b/src/ps3eyedriver.cpp
@@ -216,31 +216,52 @@ ps3eye_close(ps3eye_t *eye)
 }
 
 int
-ps3eye_set_parameters(ps3eye_t *eye, bool autogain, bool awb, uint8_t gain, uint8_t exposure,
-                      uint8_t contrast, uint8_t brightness)
+ps3eye_set_parameter(ps3eye_t *eye, ps3eye_parameter param, int value)
 {
-    
-    int err = 0;
-    if (!ps3eye_context) {
-        return -1;
-    }
     if (!eye) {
         return -1;
     }
-    
-    eye->eye->setAutogain(autogain);
-    eye->eye->setAutoWhiteBalance(awb);
-    eye->eye->setExposure(exposure);
-    //For the remaining, the values passed in do not seem to work well, so ignore.
-    //eye->eye->setGain(gain);
-    //eye->eye->setSharpness(sharpness);
-    //eye->eye->setContrast(contrast);
-    //eye->eye->setBrightness(brightness);
-    //eye->eye->setHue(hue);
-    //eye->eye->setRedBalance(redblc);
-    //eye->eye->setBlueBalance(blueblc);
-    //eye->eye->setFlip(flip_h, flip_v);
-    //ps3eye::PS3EYECam::updateDevices();
-    
-    return err;
+
+    switch (param) {
+        case PS3EYE_AUTO_GAIN:
+            eye->eye->setAutogain(value > 0);
+            break;
+        case PS3EYE_GAIN:
+            eye->eye->setGain(value);
+            break;
+        case PS3EYE_AUTO_WHITEBALANCE:
+            eye->eye->setAutoWhiteBalance(value > 0);
+            break;
+        case PS3EYE_EXPOSURE:
+            eye->eye->setExposure(value);
+            break;
+        case PS3EYE_SHARPNESS:
+            eye->eye->setSharpness(value);
+            break;
+        case PS3EYE_CONTRAST:
+            eye->eye->setContrast(value);
+            break;
+        case PS3EYE_BRIGHTNESS:
+            eye->eye->setBrightness(value);
+            break;
+        case PS3EYE_HUE:
+            eye->eye->setHue(value);
+            break;
+        case PS3EYE_REDBALANCE:
+            eye->eye->setRedBalance(value);
+            break;
+        case PS3EYE_BLUEBALANCE:
+            eye->eye->setBlueBalance(value);
+            break;
+        case PS3EYE_HFLIP:
+            eye->eye->setFlip(value > 0, eye->eye->getFlipV());
+            break;
+        case PS3EYE_VFLIP:
+            eye->eye->setFlip(eye->eye->getFlipH(), value > 0);
+            break;
+        default:
+            break;
+    }
+
+    return 0;
 }

--- a/src/ps3eyedriver.cpp
+++ b/src/ps3eyedriver.cpp
@@ -214,3 +214,33 @@ ps3eye_close(ps3eye_t *eye)
 {
     delete eye;
 }
+
+int
+ps3eye_set_parameters(ps3eye_t *eye, bool autogain, bool awb, uint8_t gain, uint8_t exposure,
+                      uint8_t contrast, uint8_t brightness)
+{
+    
+    int err = 0;
+    if (!ps3eye_context) {
+        return -1;
+    }
+    if (!eye) {
+        return -1;
+    }
+    
+    eye->eye->setAutogain(autogain);
+    eye->eye->setAutoWhiteBalance(awb);
+    eye->eye->setExposure(exposure);
+    //For the remaining, the values passed in do not seem to work well, so ignore.
+    //eye->eye->setGain(gain);
+    //eye->eye->setSharpness(sharpness);
+    //eye->eye->setContrast(contrast);
+    //eye->eye->setBrightness(brightness);
+    //eye->eye->setHue(hue);
+    //eye->eye->setRedBalance(redblc);
+    //eye->eye->setBlueBalance(blueblc);
+    //eye->eye->setFlip(flip_h, flip_v);
+    //ps3eye::PS3EYECam::updateDevices();
+    
+    return err;
+}

--- a/src/ps3eyedriver.h
+++ b/src/ps3eyedriver.h
@@ -29,6 +29,9 @@
 #ifndef PS3EYEDRIVER_H
 #define PS3EYEDRIVER_H
 
+#include <stdint.h>
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -81,6 +84,15 @@ ps3eye_grab_frame(ps3eye_t *eye, int *stride);
  **/
 void
 ps3eye_close(ps3eye_t *eye);
+    
+int
+ps3eye_set_parameters(ps3eye_t *eye, bool autogain, bool awb, uint8_t gain, uint8_t exposure,
+                        uint8_t contrast, uint8_t brightness);
+/**
+ * Sets all ps3eye parameters on device.
+ * gain: 0 <-> 63; exposure: 0 <-> 255; sharpness: 0 <-> 63; hue: 0 <-> 255;
+ * brightness: 0 <-> 255; contrast: 0 <-> 255; blueblc: 0 <-> 255; redblc: 0 <-> 255
+ **/
 
 #ifdef __cplusplus
 };

--- a/src/ps3eyedriver.h
+++ b/src/ps3eyedriver.h
@@ -29,14 +29,26 @@
 #ifndef PS3EYEDRIVER_H
 #define PS3EYEDRIVER_H
 
-#include <stdint.h>
-#include <stdbool.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct ps3eye_t ps3eye_t;
+
+typedef enum{
+    PS3EYE_AUTO_GAIN,           // [false, true]
+    PS3EYE_GAIN,                // [0, 63]
+    PS3EYE_AUTO_WHITEBALANCE,   // [false, true]
+    PS3EYE_EXPOSURE,            // [0, 255]
+    PS3EYE_SHARPNESS,           // [0 63]
+    PS3EYE_CONTRAST,            // [0, 255]
+    PS3EYE_BRIGHTNESS,          // [0, 255]
+    PS3EYE_HUE,                 // [0, 255]
+    PS3EYE_REDBALANCE,          // [0, 255]
+    PS3EYE_BLUEBALANCE,         // [0, 255]
+    PS3EYE_HFLIP,               // [false, true]
+    PS3EYE_VFLIP                // [false, true]
+} ps3eye_parameter;
 
 /**
  * Initialize and enumerate connected cameras.
@@ -84,15 +96,13 @@ ps3eye_grab_frame(ps3eye_t *eye, int *stride);
  **/
 void
 ps3eye_close(ps3eye_t *eye);
-    
-int
-ps3eye_set_parameters(ps3eye_t *eye, bool autogain, bool awb, uint8_t gain, uint8_t exposure,
-                        uint8_t contrast, uint8_t brightness);
+
 /**
- * Sets all ps3eye parameters on device.
- * gain: 0 <-> 63; exposure: 0 <-> 255; sharpness: 0 <-> 63; hue: 0 <-> 255;
- * brightness: 0 <-> 255; contrast: 0 <-> 255; blueblc: 0 <-> 255; redblc: 0 <-> 255
+ * Set a ps3eye_parameter to a value.
+ * Returns -1 if there is an error, otherwise 0.
  **/
+int
+ps3eye_set_parameter(ps3eye_t *eye, ps3eye_parameter param, int value);
 
 #ifdef __cplusplus
 };


### PR DESCRIPTION
The psmoveapi does not send parameters that are appropriate for the PS3EYE, so some of the set functions are still commented out.
