### PR TITLE
Various platform-specific fixes.

### DIFF
--- a/sdl/makefile
+++ b/sdl/makefile
@@ -16,5 +16,9 @@ LIBS += $(shell sdl-config --libs)
 $(TARGET): $(OBJECTS)
 	$(CXX) -o $@ $^ $(LIBS)
 
+debug: CXXFLAGS += -DDEBUG -g
+debug: CCFLAGS += -DDEBUG -g
+debug: $(TARGET)
+
 clean:
 	rm -f $(TARGET) $(OBJECTS)

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -3,6 +3,7 @@
 
 #if defined WIN32 || defined _WIN32 || defined WINCE
 	#include <windows.h>
+	#include <algorithm>
 #else
 	#include <sys/time.h>
 	#include <time.h>

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -779,10 +779,10 @@ bool PS3EYECam::init(uint32_t width, uint32_t height, uint8_t desiredFrameRate)
 	ov534_reg_write(0xe7, 0x3a);
 	ov534_reg_write(0xe0, 0x08);
 
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#ifdef _MSC_VER
 	Sleep(100);
 #else
-    nanosleep((struct timespec[]){{0, 100000000}}, NULL);
+    nanosleep((const struct timespec[]){{0, 100000000}}, NULL);
 #endif
 
 	/* initialize the sensor address */
@@ -790,10 +790,10 @@ bool PS3EYECam::init(uint32_t width, uint32_t height, uint8_t desiredFrameRate)
 
 	/* reset sensor */
 	sccb_reg_write(0x12, 0x80);
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#ifdef _MSC_VER
 	Sleep(10);
 #else    
-    nanosleep((struct timespec[]){{0, 10000000}}, NULL);
+    nanosleep((const struct timespec[]){{0, 10000000}}, NULL);
 #endif
 
 	/* probe the sensor */

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -400,6 +400,7 @@ int USBMgr::listDevices( std::vector<PS3EYECam::PS3EYERef>& list )
 {
     libusb_device *dev;
     libusb_device **devs;
+    libusb_device_handle *devhandle;
     int i = 0;
     int cnt;
 
@@ -415,9 +416,14 @@ int USBMgr::listDevices( std::vector<PS3EYECam::PS3EYERef>& list )
 		libusb_get_device_descriptor(dev, &desc);
 		if(desc.idVendor == PS3EYECam::VENDOR_ID && desc.idProduct == PS3EYECam::PRODUCT_ID)
 		{
-			list.push_back( PS3EYECam::PS3EYERef( new PS3EYECam(dev) ) );
-			libusb_ref_device(dev);
-			cnt++;
+			int err = libusb_open(dev, &devhandle);
+			if (err == 0)
+			{
+				libusb_close(devhandle);
+				list.push_back( PS3EYECam::PS3EYERef( new PS3EYECam(dev) ) );
+				libusb_ref_device(dev);
+				cnt++;
+			}
 		}
     }
 

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -17,9 +17,9 @@
 #include <stdint.h>
 
 #if defined(DEBUG)
-#define debug(x...) fprintf(stdout,x)
+#define debug(x,...) fprintf(stdout,x)
 #else
-#define debug(x...) 
+#define debug(x,...) 
 #endif
 
 

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -3,6 +3,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <vector>
 
 #include <memory>

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -18,9 +18,9 @@
 #include <stdint.h>
 
 #if defined(DEBUG)
-#define debug(x,...) fprintf(stdout,x)
+#define debug(...) fprintf(stdout, __VA_ARGS__)
 #else
-#define debug(x,...) 
+#define debug(...)
 #endif
 
 


### PR DESCRIPTION
Fixes for VS 2013, hombrew gcc (can then revert MinGW fix), and a fix for the two-device problem in Win 8.1.