### PR TITLE
Compiles in VS2013

### DIFF
--- a/sdl/main.cpp
+++ b/sdl/main.cpp
@@ -36,6 +36,8 @@ main(int argc, char *argv[])
     while (true) {
         while (SDL_PollEvent(&e)) {
             if (e.type == SDL_QUIT) {
+                ps3eye_close(eye);
+                ps3eye_uninit();
                 return 0;
             }
         }

--- a/sdl/makefile
+++ b/sdl/makefile
@@ -16,5 +16,9 @@ LIBS += $(shell sdl-config --libs)
 $(TARGET): $(OBJECTS)
 	$(CXX) -o $@ $^ $(LIBS)
 
+debug: CXXFLAGS += -DDEBUG -g
+debug: CCFLAGS += -DDEBUG -g
+debug: $(TARGET)
+
 clean:
 	rm -f $(TARGET) $(OBJECTS)

--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -3,6 +3,7 @@
 
 #if defined WIN32 || defined _WIN32 || defined WINCE
 	#include <windows.h>
+	#include <algorithm>
 #else
 	#include <sys/time.h>
 	#include <time.h>
@@ -399,6 +400,7 @@ int USBMgr::listDevices( std::vector<PS3EYECam::PS3EYERef>& list )
 {
     libusb_device *dev;
     libusb_device **devs;
+    libusb_device_handle *devhandle;
     int i = 0;
     int cnt;
 
@@ -414,9 +416,15 @@ int USBMgr::listDevices( std::vector<PS3EYECam::PS3EYERef>& list )
 		libusb_get_device_descriptor(dev, &desc);
 		if(desc.idVendor == PS3EYECam::VENDOR_ID && desc.idProduct == PS3EYECam::PRODUCT_ID)
 		{
-			list.push_back( PS3EYECam::PS3EYERef( new PS3EYECam(dev) ) );
-			libusb_ref_device(dev);
-			cnt++;
+			int err = libusb_open(dev, &devhandle);
+			if (err == 0)
+			{
+				libusb_close(devhandle);
+				list.push_back( PS3EYECam::PS3EYERef( new PS3EYECam(dev) ) );
+				libusb_ref_device(dev);
+				cnt++;
+
+			}
 		}
     }
 
@@ -523,7 +531,7 @@ public:
 	    } 
 	    else
 	    {
-            switch(last_packet_type)
+            switch(last_packet_type)  // ignore warning.
             {
                 case DISCARD_PACKET:
                     if (packet_type == LAST_PACKET) {
@@ -717,6 +725,7 @@ PS3EYECam::PS3EYECam(libusb_device *device)
 	contrast =  37;
 	blueblc = 128;
 	redblc = 128;
+	greenblc = 128;
     flip_h = false;
     flip_v = false;
 
@@ -778,10 +787,10 @@ bool PS3EYECam::init(uint32_t width, uint32_t height, uint8_t desiredFrameRate)
 	ov534_reg_write(0xe7, 0x3a);
 	ov534_reg_write(0xe0, 0x08);
 
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#ifdef _MSC_VER
 	Sleep(100);
 #else
-    nanosleep((struct timespec[]){{0, 100000000}}, NULL);
+    nanosleep((const struct timespec[]){{0, 100000000}}, NULL);
 #endif
 
 	/* initialize the sensor address */
@@ -789,10 +798,10 @@ bool PS3EYECam::init(uint32_t width, uint32_t height, uint8_t desiredFrameRate)
 
 	/* reset sensor */
 	sccb_reg_write(0x12, 0x80);
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#ifdef _MSC_VER
 	Sleep(10);
 #else    
-    nanosleep((struct timespec[]){{0, 10000000}}, NULL);
+    nanosleep((const struct timespec[]){{0, 10000000}}, NULL);
 #endif
 
 	/* probe the sensor */
@@ -836,6 +845,7 @@ void PS3EYECam::start()
 	setSharpness(sharpness);
 	setRedBalance(redblc);
 	setBlueBalance(blueblc);
+	setGreenBalance(greenblc);
     setFlip(flip_h, flip_v);
 
 	ov534_set_led(1);

--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -3,6 +3,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <vector>
 
 #include <memory>
@@ -17,9 +18,9 @@
 #include <stdint.h>
 
 #if defined(DEBUG)
-#define debug(x...) fprintf(stdout,x)
+#define debug(...) fprintf(stdout, __VA_ARGS__)
 #else
-#define debug(x...) 
+#define debug(...)
 #endif
 
 
@@ -124,6 +125,11 @@ public:
 		blueblc = val;
 		sccb_reg_write(0x42, val);
 	}
+	uint8_t getGreenBalance() const { return greenblc; }
+	void setGreenBalance(uint8_t val) {
+		greenblc = val;
+		sccb_reg_write(0x44, val);
+	}
     bool getFlipH() const { return flip_h; }
     bool getFlipV() const { return flip_v; }
 	void setFlip(bool horizontal = false, bool vertical = false) {
@@ -178,6 +184,7 @@ private:
 	uint8_t contrast; // 0 <-> 255
 	uint8_t blueblc; // 0 <-> 255
 	uint8_t redblc; // 0 <-> 255
+	uint8_t greenblc; // 0 <-> 255
     bool flip_h;
     bool flip_v;
 	//

--- a/src/ps3eyedriver.cpp
+++ b/src/ps3eyedriver.cpp
@@ -216,6 +216,44 @@ ps3eye_close(ps3eye_t *eye)
 }
 
 int
+ps3eye_get_parameter(ps3eye_t *eye, ps3eye_parameter param)
+{
+    if (!eye) {
+        return -1;
+    }
+    switch (param) {
+    case PS3EYE_AUTO_GAIN:
+        return eye->eye->getAutogain();
+    case PS3EYE_GAIN:
+        return eye->eye->getGain();
+    case PS3EYE_AUTO_WHITEBALANCE:
+        return eye->eye->getAutoWhiteBalance();
+    case PS3EYE_EXPOSURE:
+        return eye->eye->getExposure();
+    case PS3EYE_SHARPNESS:
+        return eye->eye->getSharpness();
+    case PS3EYE_CONTRAST:
+        return eye->eye->getContrast();
+    case PS3EYE_BRIGHTNESS:
+        return eye->eye->getBrightness();
+    case PS3EYE_HUE:
+        return eye->eye->getHue();
+    case PS3EYE_REDBALANCE:
+        return eye->eye->getRedBalance();
+    case PS3EYE_BLUEBALANCE:
+        return eye->eye->getBlueBalance();
+    case PS3EYE_GREENBALANCE:
+        return eye->eye->getGreenBalance();
+    case PS3EYE_HFLIP:
+        return eye->eye->getFlipH();
+    case PS3EYE_VFLIP:
+        return eye->eye->getFlipV();
+    default:
+        return -1;
+    }
+}
+
+int
 ps3eye_set_parameter(ps3eye_t *eye, ps3eye_parameter param, int value)
 {
     if (!eye) {
@@ -252,6 +290,9 @@ ps3eye_set_parameter(ps3eye_t *eye, ps3eye_parameter param, int value)
             break;
         case PS3EYE_BLUEBALANCE:
             eye->eye->setBlueBalance(value);
+            break;
+        case PS3EYE_GREENBALANCE:
+            eye->eye->setGreenBalance(value);
             break;
         case PS3EYE_HFLIP:
             eye->eye->setFlip(value > 0, eye->eye->getFlipV());

--- a/src/ps3eyedriver.h
+++ b/src/ps3eyedriver.h
@@ -46,6 +46,7 @@ typedef enum{
     PS3EYE_HUE,                 // [0, 255]
     PS3EYE_REDBALANCE,          // [0, 255]
     PS3EYE_BLUEBALANCE,         // [0, 255]
+    PS3EYE_GREENBALANCE,        // [0, 255]
     PS3EYE_HFLIP,               // [false, true]
     PS3EYE_VFLIP                // [false, true]
 } ps3eye_parameter;
@@ -103,6 +104,13 @@ ps3eye_close(ps3eye_t *eye);
  **/
 int
 ps3eye_set_parameter(ps3eye_t *eye, ps3eye_parameter param, int value);
+
+/**
+* Get a ps3eye_parameter value.
+* Returns -1 if there is an error, otherwise returns the parameter value int.
+**/
+int
+ps3eye_get_parameter(ps3eye_t *eye, ps3eye_parameter param);
 
 #ifdef __cplusplus
 };


### PR DESCRIPTION
Fixes for GCC (homebrew and mingw).

Fixes an issue in Win 8.1 where PS3Eye shows up as two devices, presumably camera and microphone. Microphone cannot be opened with libusb so check for lack of err in opening device.

Fix debug macro. Add debug target to sdl example.

SDL example closes camera when quiting.

Added Green balance.

Exposed paramter getters through ps3eyedriver