### PR TITLE
Switch usb event polling from using libusb_handle_events to libusb_ha…

### DIFF
--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -393,7 +393,11 @@ std::shared_ptr<USBMgr> USBMgr::instance()
 
 bool USBMgr::handleEvents()
 {
-	return (libusb_handle_events(instance()->usb_context) == 0);
+    struct timeval tv;
+    tv.tv_sec = 0;
+    tv.tv_usec = 50 * 1000; // ms
+
+    return (libusb_handle_events_timeout_completed(instance()->usb_context, &tv, NULL) == 0);
 }
 
 int USBMgr::listDevices( std::vector<PS3EYECam::PS3EYERef>& list )


### PR DESCRIPTION
…ndle_events_timeout_completed with a 50ms timeout. Internally libusb_handle_events calls libusb_handle_events_timeout_completed with a 60sec timeout. On rare occasions lib usb on Windows can stall waiting for an event to complete, resulting in a 60sec wait before the video stream recovers. Realistically, 50ms is more than long enough to wait.