### PR TITLE
Increase timer resolution in Windows so libusb calls can return faster.

### DIFF
--- a/src/ps3eye.cpp
+++ b/src/ps3eye.cpp
@@ -4,6 +4,7 @@
 #if defined WIN32 || defined _WIN32 || defined WINCE
 	#include <windows.h>
 	#include <algorithm>
+	#include <timeapi.h>
 #else
 	#include <sys/time.h>
 	#include <time.h>


### PR DESCRIPTION
I forgot a header in the last PR. This PR compiles and works, though the magnitude of the benefit is yet to be determined.